### PR TITLE
Autoloading plugins asset

### DIFF
--- a/Summernote.php
+++ b/Summernote.php
@@ -65,7 +65,7 @@ class Summernote extends InputWidget
             SummernoteLanguageAsset::register($view)->language = $language;
         }
         
-        if (count($this->plugins)) {
+        if (!empty($this->plugins) && is_array($this->plugins)) {
             SummernotePluginAsset::register($view)->plugins = $this->plugins;
         }
     }

--- a/Summernote.php
+++ b/Summernote.php
@@ -22,6 +22,8 @@ class Summernote extends InputWidget
     public $options = [];
     /** @var array */
     public $clientOptions = [];
+    /** @var array */
+    public $plugins = [];
 
     /**
      * @inheritdoc
@@ -61,6 +63,10 @@ class Summernote extends InputWidget
 
         if ($language = ArrayHelper::getValue($this->clientOptions, 'lang', null)) {
             SummernoteLanguageAsset::register($view)->language = $language;
+        }
+        
+        if (count($this->plugins)) {
+            SummernotePluginAsset::register($view)->plugins = $this->plugins;
         }
     }
 }

--- a/SummernotePluginAsset.php
+++ b/SummernotePluginAsset.php
@@ -7,7 +7,7 @@ use yii\web\AssetBundle;
 class SummernotePluginAsset extends AssetBundle
 {
     /** @var array */
-    public $plugins;
+    public $plugins = [];
     /** @var string */
     public $sourcePath = '@bower/summernote/plugin';
     /** @var array */

--- a/SummernotePluginAsset.php
+++ b/SummernotePluginAsset.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Zelenin\yii\widgets\Summernote;
+
+use yii\web\AssetBundle;
+
+class SummernotePluginAsset extends AssetBundle
+{
+    /** @var array */
+    public $plugins;
+    /** @var string */
+    public $sourcePath = '@bower/summernote/plugin';
+    /** @var array */
+    public $depends = [
+        'Zelenin\yii\widgets\Summernote\SummernoteAsset'
+    ];
+
+    /**
+     * @inheritdoc
+     */
+    public function registerAssetFiles($view)
+    {
+        foreach ($this->plugins as $plugin) {
+            $this->js[] = 'summernote-ext-' . $plugin . '.js';
+        }
+        parent::registerAssetFiles($view);
+    }
+}


### PR DESCRIPTION
Allow to load plugins asset for Summernote when 'plugins' option is set.
Usage: 
    widget(Summernote::className(), [
        'plugins' => ['PLUGIN_NAME', ...]
    ])

where PLUGIN_NAME is name of the plugin (i.e. "video" for summernote-ext-video.js)